### PR TITLE
Update remake.yml folder names to source

### DIFF
--- a/analysis/remake.yml
+++ b/analysis/remake.yml
@@ -1,4 +1,4 @@
-sources: remake/
+sources: remake
 
 packages:
   - ape


### PR DESCRIPTION
It seemed that current version of `remake` need only the name of the folder without the slash to work. Otherwise you get error.
